### PR TITLE
Remove freqlist and intlist from BaseGenerator class

### DIFF
--- a/generators/BaseGenerator.py
+++ b/generators/BaseGenerator.py
@@ -3,9 +3,7 @@ from core.Spectrum import Spectrum
 
 
 class BaseGenerator:
-    def __init__(self, freqlist, intlist, fmin, fmax, step, sigma):
-        self.freqlist = freqlist
-        self.intlist = intlist
+    def __init__(self, fmin, fmax, step, sigma):
         self.fmin = fmin
         self.fmax = fmax
         self.step = step
@@ -17,9 +15,8 @@ class BaseGenerator:
             self.frequencies.append(self.fmin + i * self.step)
 
     @classmethod
-    def initialize(cls, freqlist, intlist, fmin, fmax, step, sigma):
-        if not isinstance(freqlist, np.ndarray) or not isinstance(intlist, np.ndarray):
-            raise ValueError("The variables 'freqlist' and 'intlist' must be numpy arrays.")
+    def initialize(cls, fmin, fmax, step, sigma):
+
         if not isinstance(fmin, int) or not isinstance(fmax, int):
             raise ValueError("Varibles 'fmin' and 'fmax' must be integers.")
         if fmax <= fmin:
@@ -33,14 +30,16 @@ class BaseGenerator:
         if not isinstance(step, float):
             raise ValueError("The variable 'step' must be integer.")
         
-        return cls(freqlist, intlist, fmin, fmax, step, sigma)
+        return cls(fmin, fmax, step, sigma)
     
     def distribution_function(self, freq, sigma, x):
         pass
 
-    def generate_spectrum(self, stype):
+    def generate_spectrum(self, freqlist, intlist, stype):
+        if not isinstance(freqlist, np.ndarray) or not isinstance(intlist, np.ndarray):
+            raise ValueError("The variables 'freqlist' and 'intlist' must be numpy arrays.")
         temp = np.empty((self.nstep, len(self.freqlist)))
         for i in range(len(self.freqlist)):
             temp[:,i] = self.intlist[i] * self.distribution_function(self.freqlist[i], self.sigma, np.asarray(self.frequencies))
         self.intensities = np.sum(temp, axis=1, dtype=float)
-        return Spectrum(stype, self.frequencies, self.intensities)
+        return Spectrum.initialize(self.frequencies, self.intensities, stype)

--- a/generators/GaussianGenerator.py
+++ b/generators/GaussianGenerator.py
@@ -2,8 +2,8 @@ import numpy as np
 from generators.BaseGenerator import BaseGenerator
 
 class GaussianGenerator(BaseGenerator):
-    def __init__(self, freqlist, intlist, fmin, fmax, step, sigma):
-        super().__init__(freqlist, intlist, fmin, fmax, step, sigma)
+    def __init__(self, fmin, fmax, step, sigma):
+        super().__init__(fmin, fmax, step, sigma)
 
     def distribution_function(self, freq, sigma, x):
         return 1.0/(sigma*np.sqrt(2*np.pi))*np.exp(-0.5*((x-freq)/sigma)**2)

--- a/generators/LorentzianGenerator.py
+++ b/generators/LorentzianGenerator.py
@@ -2,8 +2,8 @@ import numpy as np
 from generators.BaseGenerator import BaseGenerator
 
 class LorentzianGenerator(BaseGenerator):
-    def __init__(self, freqlist, intlist, fmin, fmax, step, sigma):
-        super().__init__(freqlist, intlist, fmin, fmax, step, sigma)
+    def __init__(self, fmin, fmax, step, sigma):
+        super().__init__(fmin, fmax, step, sigma)
 
     def distribution_function(self, freq, sigma, x):
         return (1.0/np.pi) * (sigma/((x-freq)**2 + sigma**2))


### PR DESCRIPTION
BaseGenerator should only contain the info of the generator.
The `freqlist` and `intlist` should be passed to the `generate_spectrum` method.